### PR TITLE
Update Tracer.Report name with custom one

### DIFF
--- a/lib/new_relic/tracer.ex
+++ b/lib/new_relic/tracer.ex
@@ -58,6 +58,39 @@ defmodule NewRelic.Tracer do
     send_resp(conn, 200, "ok")
   end
   ```
+
+  ###### Customize external traces
+
+  Its possible to report external trace with custom names.
+
+  To change External Service calls names, use this syntax:
+
+  ```elixir
+  defmodule MyExternalService do
+    use NewRelic.Tracer
+
+    @trace {:query, category: :external, reported_name: :external_host}
+    def query(args) do
+      # Make the call
+    end
+
+    def external_host(_args), do: "external-domain.net"
+  end
+  ```
+
+  Alternatively it also can be set with a short and a long name:
+
+  ```elixir
+  defmodule MyExternalService do
+    use NewRelic.Tracer
+
+    @trace {:query, category: :external, reported_name_tuple: {"/users", "some-domain.net/users"}}
+    def query(args) do
+      # Make the call
+    end
+  end
+  ```
+
   """
 
   defmacro __using__(_args) do

--- a/test/metric_transaction_test.exs
+++ b/test/metric_transaction_test.exs
@@ -90,7 +90,6 @@ defmodule MetricTransactionTest do
     assert [_, [1, _, _, _, _, _]] = apdex
 
     assert TestHelper.find_metric(metrics, "External/MetricTransactionTest.External.call/all")
-    assert TestHelper.find_metric(metrics, "External/allWeb")
   end
 
   test "Failed transaction" do

--- a/test/other_transaction_test.exs
+++ b/test/other_transaction_test.exs
@@ -63,7 +63,6 @@ defmodule OtherTransactionTest do
     assert TestHelper.find_metric(metrics, "OtherTransaction/TransactionCategory/MyTaskName")
 
     assert TestHelper.find_metric(metrics, "External/OtherTransactionTest.External.call/all")
-    assert TestHelper.find_metric(metrics, "External/allOther")
 
     span_events = TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
     assert length(span_events) == 3

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -161,7 +161,7 @@ defmodule SpanEventTest do
 
     [http_request, _, _] =
       Enum.find(span_events, fn [ev, _, _] ->
-        ev[:name] == "SpanEventTest.Traced.http_request/0"
+        ev[:name] == "SpanEventTest.Traced.http_request"
       end)
 
     assert function[:category] == "generic"
@@ -200,7 +200,7 @@ defmodule SpanEventTest do
 
     [nested_event, _, _] =
       Enum.find(span_events, fn [ev, _, _] ->
-        ev[:name] == "SpanEventTest.Traced.http_request/0"
+        ev[:name] == "SpanEventTest.Traced.http_request"
       end)
 
     [[_intrinsics, tx_event]] = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -186,13 +186,13 @@ defmodule TransactionTest do
 
     assert Enum.find(tx_events, fn [_, event] ->
              event[:path] == "/service" && event[:external_call_count] == 2 &&
-               event[:"external.TransactionTest.ExternalService.query.call_count"] == 2 &&
+               event[:"external.TransactionTest.ExternalService.query/1.call_count"] == 2 &&
                event[:status] == 200
            end)
 
     assert Enum.find(events, fn [_, event, _] ->
              event[:category] == :Metric && event[:name] == :FunctionTrace &&
-               event[:mfa] == "TransactionTest.ExternalService.query/1" && event[:call_count] == 2
+               event[:mfa] == "TransactionTest.ExternalService.query" && event[:call_count] == 2
            end)
 
     assert Enum.find(events, fn [_, event, _] ->


### PR DESCRIPTION
Re add the custom external reported name with special `Tracer.Report.call` clausule.

So it reports the external calls as urls or custom names.

Also `dry`ed a little bit the `NewRelic.Tracer.Report` module.

cc @britto
