### PR TITLE
Update api to remove responsability of the library to coerce the urls

### DIFF
--- a/test/metric_tracer_test.exs
+++ b/test/metric_tracer_test.exs
@@ -23,13 +23,19 @@ defmodule MetricTracerTest do
     def query do
     end
 
-    @trace {:named_external, category: :external, metric_name: {__MODULE__, :report_name}}
-    def named_external(path), do: path
+    @trace {:named_external, category: :external, metric_name: "domain.net"}
+    def named_external do
+    end
+
+    @trace {:named_external_callback_arg,
+            category: :external, metric_name: {__MODULE__, :report_name}}
+    def named_external_callback_arg(path), do: path
 
     def report_name(path), do: "domain.net#{path}"
 
-    @trace {:named_external, category: :external, metric_name: {__MODULE__, :default_name}}
-    def named_external_default_name do
+    @trace {:named_external_callback,
+            category: :external, metric_name: {__MODULE__, :default_name}}
+    def named_external_callback do
     end
 
     def default_name, do: "domain.net"
@@ -60,18 +66,27 @@ defmodule MetricTracerTest do
            )
   end
 
-  test "External metrics name with args" do
-    MetricTraced.named_external("/query")
-    MetricTraced.named_external("/query")
+  test "External metrics name" do
+    MetricTraced.named_external()
+    MetricTraced.named_external()
+
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
+
+    assert TestHelper.find_metric(metrics, "External/domain.net/all", 2)
+  end
+
+  test "External metrics callback name with args" do
+    MetricTraced.named_external_callback_arg("/query")
+    MetricTraced.named_external_callback_arg("/query")
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
     assert TestHelper.find_metric(metrics, "External/domain.net/query/all", 2)
   end
 
-  test "External metrics name without args" do
-    MetricTraced.named_external_default_name()
-    MetricTraced.named_external_default_name()
+  test "External metrics callback name without args" do
+    MetricTraced.named_external_callback()
+    MetricTraced.named_external_callback()
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 

--- a/test/metric_tracer_test.exs
+++ b/test/metric_tracer_test.exs
@@ -23,6 +23,17 @@ defmodule MetricTracerTest do
     def query do
     end
 
+    @trace {:named_external, category: :external, metric_name: {__MODULE__, :report_name}}
+    def named_external(path), do: path
+
+    def report_name(path), do: "domain.net#{path}"
+
+    @trace {:named_external, category: :external, metric_name: {__MODULE__, :default_name}}
+    def named_external_default_name do
+    end
+
+    def default_name, do: "domain.net"
+
     @trace {:db_query, category: :datastore}
     def db_query do
     end
@@ -47,6 +58,24 @@ defmodule MetricTracerTest do
              "External/MetricTracerTest.MetricTraced.custom_name:special/all",
              2
            )
+  end
+
+  test "External metrics name with args" do
+    MetricTraced.named_external("/query")
+    MetricTraced.named_external("/query")
+
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
+
+    assert TestHelper.find_metric(metrics, "External/domain.net/query/all", 2)
+  end
+
+  test "External metrics name without args" do
+    MetricTraced.named_external_default_name()
+    MetricTraced.named_external_default_name()
+
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
+
+    assert TestHelper.find_metric(metrics, "External/domain.net/all", 2)
   end
 
   test "Datastore metrics" do


### PR DESCRIPTION
# Add new trace option for external calls

The goal is to get insights about external calls and which one might be under performing.

## New external call trace api

This PRs adds a new option on external calls tracer to change the metric name. This can improve how you track performance of you external calls.

The current API still works exactly before, it will set the metric name for the module + function name of your call if no `:metric_name` is sent. But when a `:metric_name` is passed, it will override the module + function name.

A `:metric_name` can be defined in two ways, the first one is a string or a `{Module, :function}` that will be called with the function args to return the string, allowing name to be defined at runtime. Below is the examples of usage of the `@trace` with the current and new apis.
The metric name includes the `External/` and `/all` since they are necessary for NewRelic api to process the metric correctly.

```elixir
defmodule ModuleExample do
  @trace {:query_all, category: :external}
  def query_all do
  end
  # Metric name: External/ModuleExample.query_all/all
  
  @trace {:query_users, category: :external, metric_name: "domain.net/users"}
  def query_users do
  end
  # Metric name: External/domain.net/users/all  
  
  @trace {:query_any_entity, category: :external, metric_name: {__MODULE__, :entity_name}}
  def query_any_entity(entity) do
  end
  # Metric name: External/domain.net/ENTITY_NAME_GIVEN_ON_RUNTIME/all    
  
  def entity_name(%{name: name} = _entity), do: "domain.net/#{name}"
end
```

This is helpful for HTTP clients implementations like HTTPoison.

```elixir
defmodule Instrumented.HTTPClient do
  use HTTPoison.Base
  
  @trace {:request, category: :external, metric_name: {__MODULE__, :metric_name}}
  def request(method, url, body \\ "", headers \\ [], options \\ []) do
    super(method, url, body, headers, options)
  end

  def metric_name(_method, url, _body, _headers, _options) do
    case :http_uri.parse(url) do
      {:ok, {_, _, host, _, path, _}} -> "#{host}#{path}"
      {:error, _} -> url
    end
  end
end
```